### PR TITLE
helm: Fix traefik without tls option

### DIFF
--- a/charts/flatline/templates/traefik.yaml
+++ b/charts/flatline/templates/traefik.yaml
@@ -89,10 +89,10 @@ spec:
     {{- end }}
   tls:
     secretName: {{ $ctx.componentValues.tls.secretName | default (include "common.fullnameWithComponent" $ctx) }}
+    {{- if $ctx.componentValues.tls.optionsName }}
     options:
-      {{- if $ctx.componentValues.tls.optionsName }}
       name: {{ $ctx.componentValues.tls.optionsName }}
-      {{- end }}
+    {{- end }}
 
 ---
 


### PR DESCRIPTION
I didn't copy the error, but it is basically "tls.options can't be null". As `tls.options.name` is our only option, we should not include any option if it is null.